### PR TITLE
feat: Prepare to be a Go template repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
+# TODO: @memes - update to match requirements
+# spell-checker: disable
 ---
 version: 2
 updates:
-  - package-ecosystem: "bundler"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -13,15 +15,13 @@ updates:
       interval: "weekly"
     reviewers:
       - memes
-  # TODO @memes - remove if not a go project
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
     reviewers:
       - memes
-  # TODO @memes - remove if repo doesn't contain Terraform
-  - package-ecosystem: "terraform"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,4 +1,3 @@
-# TODO @memes remove is not a golang project
 # These github actions will perform linting and go tests
 # spell-checker: disable
 ---
@@ -16,7 +15,7 @@ permissions:
 
 jobs:
   go-mod-tidy:
-    # TODO @memes enable if this is a go project
+    # TODO: @memes - enable in real go project
     if: false
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +29,7 @@ jobs:
       - name: Verify go.mod and go.sum are up to date
         run: go mod tidy && git diff --exit-code -- go.mod go.sum
   golangci-lint:
-    # TODO @memes enable if this is a go project
+    # TODO: @memes - enable in real go project
     if: false
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +45,7 @@ jobs:
         with:
           version: latest
   go-test:
-    # TODO @memes enable if this is a go project
+    # TODO: @memes - enable in real go project
     if: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,4 +1,3 @@
-# TODO @memes remove is not a golang project
 # spell-checker: disable
 ---
 name: go-release
@@ -16,6 +15,8 @@ permissions:
 
 jobs:
   goreleaser:
+    # TODO: @memes - enable in real go project
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,8 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
 permissions:
   contents: read
   pull-requests: read
@@ -22,20 +23,11 @@ jobs:
         run: |
           sudo curl -sLo /usr/local/bin/talisman https://github.com/thoughtworks/talisman/releases/download/v1.31.0/talisman_linux_amd64
           sudo chmod 0755 /usr/local/bin/talisman
-      - name: Install terraform-docs
-        run: |
-          sudo sh -c 'curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | tar xzf - -C /usr/local/bin'
-          sudo chmod 0755 /usr/local/bin/terraform-docs
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2.2'
-          bundler-cache: true
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - uses: pre-commit/action@v3.0.0
-  # TODO @memes - this is enabled in repo-template but should be disabled as
-  # necessary
+  # TODO: @memes - remove if not using a Dockerfile
   hadolint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,17 +14,14 @@ permissions:
 
 jobs:
   release-please:
-    # TODO @memes - enable release-please action as needed
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
         uses: GoogleCloudPlatform/release-please-action@v4.0.2
         with:
-          # TODO @memes - make sure release-type and package-name are correct.
+          # TODO @memes - make sure package-name is correct.
           release-type: go
-          package-name: repo-template
-          # TODO @memes - If this is a go project, or if other actions are to be
-          # triggered by the result of this action, set token to a secret with
-          # a GitHub PAT as content.
-          # token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          package-name: go-template
+          # TODO @memes - If other actions are not going to be triggered by the
+          # result of this action this can be removed.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-# TODO @mmes - remove if not a golang project
 # spell-checker: disable
 ---
 run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# TODO: @memes - remove unused plugins for project
+# TODO: @memes - review and add/remove plugins
 ---
 # spell-checker:disable
 repos:
@@ -7,18 +7,16 @@ repos:
     hooks:
       - id: yamllint
         files: \.(yml|yaml|talismanrc)$
-        types: [file, yaml]
+        types:
+          - file
+          - yaml
         entry: yamllint --strict
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.0.0
     hooks:
-      - id: terraform_fmt
-      - id: terraform_docs
-        args: ['--args=--sort-by=required --hide=providers']
-  - repo: https://github.com/mattlqx/pre-commit-ruby
-    rev: v1.3.5
-    hooks:
-      - id: rubocop
+      - id: conventional-pre-commit
+        stages:
+          - commit-msg
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.6
     hooks:
@@ -28,8 +26,14 @@ repos:
     hooks:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
+      - id: check-toml
       - id: detect-private-key
       - id: end-of-file-fixer
+      # TODO: @memes - remove/modify if push to main is allowed
+      - id: no-commit-to-branch
+        args:
+          - -b
+          - main
       - id: trailing-whitespace
   - repo: https://github.com/thoughtworks/talisman
     rev: v1.31.0

--- a/.talismanrc
+++ b/.talismanrc
@@ -8,3 +8,7 @@ fileignoreconfig:
   checksum: 1a73442a316535a2e8a67a401aef15943f73ab0e405577f6f405e81400a12d57
 - filename: .github/workflows/pre-commit.yml
   checksum: d973823a6d233c44075ad96c2f92e2d2522b3c5767ef6e8376f0731e8a55ab38
+- filename: README.md
+  ignore_detectors:
+  - filecontent
+version: "1.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,21 +14,22 @@ applied.
 [pre-commit] is used to ensure that all files have consistent formatting and to
 avoid committing secrets.
 
-<!-- TODO @memes - update if not a go project -->
-[golangci-lint] is used to enforce Go code passes
-linting and formatting rules ([gofumpt] is the expected Go code formatter). Rules
-are defined in [.golangci.yml](.golangci.yml).
+[golangci-lint] is used to enforce Go code passes linting and formatting rules
+([gofumpt] is the expected Go code formatter). Rules are defined in
+[.golangci.yml](.golangci.yml).
 
-1. Install [pre-commit] in a virtual python environment or globally: see [instructions](https://pre-commit.com/#installation)
-2. Install [golangci-lint] from a binary or from source: see [instructions](https://golangci-lint.run/usage/install/#local-installation)
+1. Install [pre-commit] in a virtual python environment or globally: see
+   [instructions](https://pre-commit.com/#installation)
+2. Install [golangci-lint] from a binary or from source: see
+   [instructions](https://golangci-lint.run/usage/install/#local-installation)
 3. Fork and clone this repo
 4. Install pre-commit hook to git
 
    E.g.
 
    ```shell
-   pip install pre-commit
-   pre-commit install
+   pip install -r requirements-dev.txt
+   pre-commit install --hook-type commit-msg --hook-type pre-commit
    ```
 
 5. Create a new branch for changes
@@ -46,6 +47,5 @@ are defined in [.golangci.yml](.golangci.yml).
    during `git commit`.
 
 [pre-commit]: https://pre-commit.com/
-<!-- TODO @memes - remove if not a go project -->
 [gofumpt]: https://github.com/mvdan/gofumpt
 [golangci-lint]: https://golangci-lint.run/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# repo-template
+# go-template
 
-![GitHub release](https://img.shields.io/github/v/release/memes/repo-template?sort=semver)
-![Maintenance](https://img.shields.io/maintenance/yes/2023)
+<!-- TODO: @memes - update badges as needed -->
+[![Go Reference](https://pkg.go.dev/badge/github.com/memes/go-template.svg)](https://pkg.go.dev/github.com/memes/go-template)
+[![Go Report Card](https://goreportcard.com/badge/github.com/memes/go-template)](https://goreportcard.com/report/github.com/memes/go-template)
+![GitHub release](https://img.shields.io/github/v/release/memes/go-template?sort=semver)
+![Maintenance](https://img.shields.io/maintenance/yes/2024)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 This repository contains common settings and actions that I tend to use in my
-demos and projects.
+Go projects.
 
 ## Setup
 
@@ -15,20 +18,15 @@ demos and projects.
 1. Use as a template when creating a new GitHub repo, or copy the contents into
    a bare-repo directory.
 
-2. Remove Go tooling if needed, or update it to make sure it meets repo layout
-
-   - `.github/workflows/go-lint.yml`
-   - `.github/workflows/go-release.yml`
-   - `.golangci.yml`
-   - `.goreleaser.yml`
-   - `Dockerfile`
-
-3. Update `.pre-commit-config.yml` to add/remove plugins as necessary.
-4. Create `.envrc` and `.tool-versions` for asdf and direnv integration;
-   `dot.envrc` and `dot.tool-versions` provide starting points.
-5. Modify README.md and CONTRIBUTING.md, change LICENSE as needed.
-6. Review GitHub PR and issue templates.
-7. If using `release-please` action, make sure that _Settings_ > _Action_ >
-   _General_  > _Allow GitHub Actions to create and approve pull requests_ is
-   checked.
+2. Update `.pre-commit-config.yml` to add/remove plugins as necessary.
+3. Modify README.md and CONTRIBUTING.md, change LICENSE as needed.
+4. Review GitHub PR and issue templates.
+5. If pushing container(s) to Docker Hub, make these changes to repo settings:
+   1. _Settings_ > _Secrets and Variables_ > _Actions_, and add `DOCKERHUB_USERNAME`
+      and `DOCKERHUB_TOKEN` as _Repository Secret_.
+6. If using `release-please` action, make these changes:
+   1. In GitHub Settings:
+      * _Settings_ > _Actions_ > _General_  > _Allow GitHub Actions to create and approve pull requests_ is checked
+      * _Settings_ > _Secrets and Variables_ > _Actions_, and add `RELEASE_PLEASE_TOKEN` with PAT as a _Repository Secret_
+7. Remove all [CHANGELOG](CHANGELOG.md) entries.
 8. Commit changes.

--- a/dot.envrc
+++ b/dot.envrc
@@ -1,8 +1,0 @@
-# TODO: @memes - update as necessary and rename to .envrc
-use asdf
-
-# Python via .tool-versions
-layout python
-
-# Ruby via .tool-versions
-# layout ruby

--- a/dot.tool-versions
+++ b/dot.tool-versions
@@ -1,4 +1,0 @@
-# TODO: @memes - update as necessary and rename to .tool-versions
-python 3.10.9 3.8.16
-# ruby 3.0.4
-terraform 1.3.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Python requirements for hacking on this repo
+pre-commit==3.6.0
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Python requirements for this repo


### PR DESCRIPTION
This brings in most of the changes from `repo-template` that are relevant for Go projects, and adjusts the focus of the remaining files to be Go only.

NOTE: The GitHub actions for linting and releasing are disabled and must be enabled when used for a real Go project.