### PR TITLE
ci: Do not run pre-commit action on push to main

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,8 +8,9 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches:
+    branches-ignore:
       - main
+
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
The pre-commit configuration will flag any attempt to push to main so disable the action for that scenario.