### PR TITLE
ci: Setup release-please for repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,9 +19,10 @@ jobs:
       - name: Release Please
         uses: GoogleCloudPlatform/release-please-action@v4.0.2
         with:
-          # TODO @memes - make sure package-name is correct.
-          release-type: go
-          package-name: go-template
+          # TODO: @memes - change release-type and package-name, and remove
+          release-type: simple
+          # release-type: go
+          # package-name: go-template
           # TODO @memes - If other actions are not going to be triggered by the
           # result of this action this can be removed.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,5 +28,8 @@ Go projects.
    1. In GitHub Settings:
       * _Settings_ > _Actions_ > _General_  > _Allow GitHub Actions to create and approve pull requests_ is checked
       * _Settings_ > _Secrets and Variables_ > _Actions_, and add `RELEASE_PLEASE_TOKEN` with PAT as a _Repository Secret_
+   2. Modify [release-please action](.github/workflows/release-please.yml) to be
+      a Go release
+   3. Remove [version.txt](version.txt)
 7. Remove all [CHANGELOG](CHANGELOG.md) entries.
 8. Commit changes.


### PR DESCRIPTION
This repo is intended to be a template for a Go
project but doesn't contain any Go code. So run
release-please as a simple project in the template but add instructions for cloned projects to enable Go package versioning.