### PR TITLE
ci: Disable release-please for template

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,15 +14,15 @@ permissions:
 
 jobs:
   release-please:
+    # TODO: @memes - enable in real go project
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
         uses: GoogleCloudPlatform/release-please-action@v4.0.2
         with:
-          # TODO: @memes - change release-type and package-name, and remove
-          release-type: simple
-          # release-type: go
-          # package-name: go-template
+          release-type: go
+          package-name: go-template
           # TODO @memes - If other actions are not going to be triggered by the
           # result of this action this can be removed.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Go projects.
    1. In GitHub Settings:
       * _Settings_ > _Actions_ > _General_  > _Allow GitHub Actions to create and approve pull requests_ is checked
       * _Settings_ > _Secrets and Variables_ > _Actions_, and add `RELEASE_PLEASE_TOKEN` with PAT as a _Repository Secret_
-   2. Modify [release-please action](.github/workflows/release-please.yml) to be
-      a Go release
+   2. Modify [release-please action](.github/workflows/release-please.yml) to have the correct package and enable
    3. Remove [version.txt](version.txt)
-7. Remove all [CHANGELOG](CHANGELOG.md) entries.
-8. Commit changes.
+7. Review and enable [go-lint](.github/workflows/go-lint.yml) and [go-release](.github/workflows/go-release.yml) actions
+8. Remove all [CHANGELOG](CHANGELOG.md) entries.
+9. Commit changes.


### PR DESCRIPTION
No point in generating releases for the template repo, so disable the action and add instructions to enable.