### PR TITLE
chore(gitignore): Remove Ruby and Terraform patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,15 +5,3 @@
 
 # Ignore generated Gorelease binaries
 dist/
-
-# Ignore Ruby
-.bundle
-Gemfile.lock
-
-# Ignore Terraform state and automatic var files - except examples
-.terraform
-.terraform.lock.hcl
-terraform.tfstate*
-*.auto.tfvars*
-terraform.tfvars*
-!terraform.tfvars.example


### PR DESCRIPTION
Since this is a Go template, no need to automatically ignore Ruby and Terraform files.