### PR TITLE
chore: Update conventional-pre-commit to v3.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
           - yaml
         entry: yamllint --strict
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.0.0
+    rev: v3.1.0
     hooks:
       - id: conventional-pre-commit
         stages:


### PR DESCRIPTION
Updating to v3.1.0 fixes an issue with templated commit messages.