### PR TITLE
ci: golangci-lint cfg exportloopref=>copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - depguard
     - dogsled
     - dupl
@@ -18,7 +19,6 @@ linters:
     - err113
     - errcheck
     - errorlint
-    - exportloopref
     - gochecknoglobals
     - gochecknoinits
     - goconst


### PR DESCRIPTION
The exportloopref linter is deprecated in golangci-lint 1.60.3, with a recommendation to replace with copyloopvar linter.