### PR TITLE
ci: Update golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  uniq-by-line: false
 linters:
   disable-all: true
   enable:
@@ -129,5 +130,4 @@ output:
     - format: tab
   print-issued-lines: false
   print-linter-name: true
-  uniq-by-line: false
   sort-results: true


### PR DESCRIPTION
Moves uniq-by-line directive from `output` to `issues`.